### PR TITLE
feat: 更新 Hero 组件的文本类型以适应不同屏幕，添加 BookOpenIcon 图标到导航栏

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -36,13 +36,31 @@ export default function Hero() {
       <div className="relative z-10 mx-auto max-w-6xl px-4 sm:px-6 pt-16 sm:pt-24 lg:pt-28 pb-10">
         <div className="flex flex-col items-center text-center gap-6">
             <h1 className="slogan text-5xl sm:text-5xl font-semibold tracking-tight brand-text">
-              <TextType
-                text={["AstrBot", "We rise together", "back to the moon and beyond"]}
-                typingSpeed={75}
-                pauseDuration={1500}
-                showCursor={true}
-                cursorCharacter="_"
-              />
+              {/* 移动端：仅打 AstrBot */}
+              <span className="block sm:hidden">
+                <TextType
+                  text={["AstrBot AI", "OmniMind"]}
+                  typingSpeed={75}
+                  pauseDuration={1500}
+                  showCursor={true}
+                  cursorCharacter="_"
+                />
+              </span>
+              {/* 桌面端：完整打字内容 */}
+              <span className="hidden sm:grid">
+                <span className="col-start-1 row-start-1">
+                  <TextType
+                    text={["AstrBot AI", "We rise together", "back to the moon and beyond"]}
+                    typingSpeed={75}
+                    pauseDuration={1500}
+                    showCursor={true}
+                    cursorCharacter="_"
+                  />
+                </span>
+                <span className="col-start-1 row-start-1 invisible select-none pointer-events-none" aria-hidden>
+                  back to the moon and beyond
+                </span>
+              </span>
             </h1>
             {/* Subtitle removed as requested */}
             <Reveal className="trendshift-badge mt-6 flex flex-wrap sm:flex-nowrap justify-center gap-3" delay={300}>

--- a/src/components/home/Navbar.tsx
+++ b/src/components/home/Navbar.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { useI18n } from "../i18n/I18nProvider";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
-import { DocumentTextIcon, MapIcon, PuzzlePieceIcon, GlobeAmericasIcon, GlobeAsiaAustraliaIcon } from "@heroicons/react/24/outline";
+import { DocumentTextIcon, MapIcon, PuzzlePieceIcon, GlobeAmericasIcon, GlobeAsiaAustraliaIcon, BookOpenIcon } from "@heroicons/react/24/outline";
 
 export default function Navbar() {
   const [openLang, setOpenLang] = useState(false);
@@ -81,8 +81,9 @@ export default function Navbar() {
         </div>
         <ul className="hidden md:flex items-center gap-3 text-sm">
           <li>
-            <a href="https://docs.astrbot.app/what-is-astrbot.html" className="inline-flex items-center h-9 px-3 rounded-full border border-ui opacity-80 hover:opacity-100 transition duration-200">
-              {t("nav.quickStart")}
+            <a href="https://docs.astrbot.app/what-is-astrbot.html" className="inline-flex items-center gap-2 h-9 px-3 rounded-full border border-ui opacity-80 hover:opacity-100 transition duration-200">
+              <BookOpenIcon className="w-4 h-4" aria-hidden />
+              <span>{t("nav.quickStart")}</span>
             </a>
           </li>
           
@@ -189,7 +190,12 @@ export default function Navbar() {
           <div className="mx-auto max-w-6xl px-4 sm:px-6 pb-4 mt-2">
             <div className="rounded-2xl border border-ui bg-background/90 backdrop-blur shadow-lg p-4 animate-dropdown origin-top">
               <ul className="flex flex-col gap-2 text-sm">
-                <li><a href="https://docs.astrbot.app/what-is-astrbot.html" className="inline-flex items-center h-10 px-3 rounded-full border border-ui opacity-80 hover:opacity-100 transition">{t("nav.quickStart")}</a></li>
+                <li>
+                  <a href="https://docs.astrbot.app/what-is-astrbot.html" className="inline-flex items-center gap-2 h-10 px-3 rounded-full border border-ui opacity-80 hover:opacity-100 transition">
+                    <BookOpenIcon className="w-4 h-4" aria-hidden />
+                    <span>{t("nav.quickStart")}</span>
+                  </a>
+                </li>
                 <li>
                   <a href="https://plugins.astrbot.app/" className="inline-flex items-center gap-2 h-10 px-3 rounded-full border border-ui opacity-80 hover:opacity-100 transition">
                     <PuzzlePieceIcon className="w-4 h-4" aria-hidden />
@@ -211,13 +217,14 @@ export default function Navbar() {
                 <li>
                   <a
                     href="https://github.com/AstrBotDevs/AstrBot"
-                    className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-ui opacity-80 hover:opacity-100 transition"
+                    className="inline-flex items-center gap-2 h-10 px-3 rounded-full border border-ui opacity-80 hover:opacity-100 transition"
                     aria-label={t("nav.github")}
                     title="GitHub"
                   >
                     <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
                       <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.38.6.1.82-.26.82-.58 0-.29-.01-1.05-.02-2.06-3.34.73-4.04-1.61-4.04-1.61-.55-1.4-1.34-1.77-1.34-1.77-1.1-.77.08-.76.08-.76 1.22.09 1.86 1.26 1.86 1.26 1.08 1.87 2.83 1.33 3.52 1.02.11-.8.42-1.33.76-1.64-2.67-.31-5.47-1.37-5.47-6.08 0-1.34.47-2.44 1.24-3.3-.12-.31-.54-1.55.12-3.22 0 0 1.01-.33 3.31 1.26.96-.27 1.98-.4 3-.41 1.02 0 2.04.14 3 .41 2.3-1.59 3.31-1.26 3.31-1.26.66 1.67.24 2.91.12 3.22.77.86 1.24 1.96 1.24 3.3 0 4.72-2.8 5.77-5.47 6.08.43.38.81 1.1.81 2.22 0 1.61-.02 2.91-.02 3.31 0 .32.22.69.82.57C20.56 21.79 24 17.3 24 12 24 5.37 18.63 0 12 0Z" />
                     </svg>
+                    <span>{t("nav.github")}</span>
                   </a>
                 </li>
               </ul>

--- a/src/components/home/Plugins.tsx
+++ b/src/components/home/Plugins.tsx
@@ -13,6 +13,12 @@ export default function Plugins() {
   const [loading, setLoading] = useState<boolean>(true);
   const [hasFetched, setHasFetched] = useState<boolean>(false);
   const sectionRef = useRef<HTMLDivElement | null>(null);
+  // 保持与 CardSwap 一致的尺寸与间距，避免骨架屏与实卡片间距不一致
+  const CARD_WIDTH = 520;
+  const CARD_HEIGHT = 180;
+  const CARD_DISTANCE = 54;
+  const VERTICAL_DISTANCE = 54;
+  const SKEW = 6; // 与 CardSwap 默认 skewAmount 一致
   useEffect(() => {
     const fetchLocal = () => {
       setLoading(true);
@@ -70,16 +76,52 @@ export default function Plugins() {
           </div>
           <div className="relative h-[420px] sm:h-[480px] lg:h-[560px] lg:justify-self-end w-full">
           {loading ? (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <div className="loader-ring" aria-label="loading" />
+            // 3D 骨架屏：在加载时展示与 CardSwap 一致的 3D 堆叠与间距，但不启动轮播
+            <div
+              className="absolute bottom-0 right-0 transform translate-x-[5%] translate-y-[20%] origin-bottom-right perspective-[900px] overflow-visible max-[1024px]:translate-x-[10%] max-[1024px]:translate-y-[15%] max-[1024px]:scale-[0.9] max-[768px]:right-auto max-[768px]:left-1/2 max-[768px]:origin-bottom max-[768px]:-translate-x-1/2 max-[768px]:translate-y-[10%] max-[768px]:scale-[0.8] max-[480px]:translate-y-[5%] max-[480px]:scale-[0.65]"
+              style={{ width: CARD_WIDTH, height: CARD_HEIGHT }}
+              aria-busy="true"
+              aria-live="polite"
+            >
+              {Array.from({ length: 9 }).map((_, i, arr) => {
+                const total = arr.length;
+                const x = i * CARD_DISTANCE;
+                const y = -i * VERTICAL_DISTANCE;
+                const z = -i * CARD_DISTANCE * 1.5;
+                const zIndex = total - i;
+                const transform = `translate(-50%, -50%) translate3d(${x}px, ${y}px, ${z}px) skewY(${SKEW}deg)`;
+                return (
+                  <Card
+                    key={`skeleton-${i}`}
+                    style={{ width: CARD_WIDTH, height: CARD_HEIGHT, transform, zIndex: zIndex as unknown as number }}
+                    className="p-5 sm:p-6 select-none pointer-events-none"
+                    aria-hidden="true"
+                  >
+                    <div className="h-full w-full">
+                      <div className="animate-pulse">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="h-4 w-32 sm:w-40 rounded bg-foreground/10" />
+                          <div className="h-4 w-10 rounded bg-foreground/10" />
+                        </div>
+                        <div className="mt-4 space-y-2">
+                          <div className="h-3 w-[90%] rounded bg-foreground/10" />
+                          <div className="h-3 w-[85%] rounded bg-foreground/10" />
+                          <div className="h-3 w-[70%] rounded bg-foreground/10" />
+                        </div>
+                        <div className="mt-5 h-4 w-20 rounded bg-foreground/10" />
+                      </div>
+                    </div>
+                  </Card>
+                );
+              })}
             </div>
           ) : plugins.length > 0 ? (
             <>
               <CardSwap
-                width={520}
-                height={180}
-                cardDistance={54}
-                verticalDistance={54}
+                width={CARD_WIDTH}
+                height={CARD_HEIGHT}
+                cardDistance={CARD_DISTANCE}
+                verticalDistance={VERTICAL_DISTANCE}
                 delay={5200}
                 pauseOnHover
                 onCardClick={(idx) => {


### PR DESCRIPTION
## Sourcery 总结

通过为插件（Plugins）添加 3D 堆叠骨架加载器、根据视口调整 Hero 文本打字效果，并使用 `BookOpenIcon` 和一致的样式丰富导航栏链接，从而实现响应式 UI 增强。

增强功能：
- 将插件（Plugins）中的加载环替换为 3D 堆叠骨架屏，并将 `CardSwap` 的尺寸集中到常量中
- 调整 Hero 组件的打字效果，使其在移动设备上显示较短的文本序列，在桌面设备上显示完整文本，以避免布局偏移
- 在桌面和移动导航菜单的 QuickStart 链接中添加 `BookOpenIcon`，并更新 GitHub 链接样式以包含文本标签

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement responsive UI enhancements by adding a 3D stacked skeleton loader to Plugins, adjusting Hero text typing per viewport, and enriching navbar links with BookOpenIcon and consistent styling.

Enhancements:
- Replace the loader ring in Plugins with a 3D stacked skeleton screen and centralize CardSwap dimensions into constants
- Adapt Hero component’s typing effect to display a shorter sequence on mobile and the full text on desktop to avoid layout shifts
- Add BookOpenIcon to QuickStart links in both desktop and mobile nav menus and update GitHub link styling to include text labels

</details>