### PR TITLE
fix: 调整离开动画的延迟时间以避免闪烁效果

### DIFF
--- a/src/components/ui/ImageToTop.tsx
+++ b/src/components/ui/ImageToTop.tsx
@@ -189,7 +189,7 @@ export default function ImageToTop({
         }
 
         /* show third frame immediately while leaving to avoid flashing frame1 */
-        .back-to-top.leaving::after { animation: end-fade-in 60ms linear forwards; }
+        .back-to-top.leaving::after { animation: end-fade-in 60ms linear 180ms forwards; }
 
         @keyframes slide-in  { from { right: calc(-1 * var(--frame-w)); } to { right: 0; } }
         @keyframes slide-out { from { right: 0; }                          to { right: calc(-1 * var(--frame-w)); } }


### PR DESCRIPTION
## Sourcery 总结

错误修复：
- 在 `.back-to-top.leaving` 元素的结束淡入动画中引入 180 毫秒的延迟，以防止闪烁效果

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Introduce a 180ms delay to the end-fade-in animation on .back-to-top.leaving to prevent flashing effects

</details>