### PR TITLE
feat: 添加磨砂玻璃导航和下拉菜单样式

### DIFF
--- a/src/assets/globals.css
+++ b/src/assets/globals.css
@@ -299,3 +299,101 @@ a, button, input, textarea {
 html.dark .logo-mono, :root[data-theme="dark"] .logo-mono {
   filter: grayscale(1) brightness(0) invert(1) contrast(2);
 }
+
+/* =====================================
+   Frosted glass nav (macOS Dock vibe)
+   ===================================== */
+.glass-nav {
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.10) 0%,
+    rgba(255, 255, 255, 0.05) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-top-color: rgba(255, 255, 255, 0.28);
+  backdrop-filter: saturate(150%) blur(18px);
+  -webkit-backdrop-filter: saturate(150%) blur(18px);
+  box-shadow:
+    0 12px 30px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.06);
+}
+.dark .glass-nav, :root[data-theme="dark"] .glass-nav {
+  background: linear-gradient(
+    180deg,
+    rgba(20, 20, 22, 0.55) 0%,
+    rgba(20, 20, 22, 0.38) 100%
+  );
+  border-color: rgba(255, 255, 255, 0.10);
+  border-top-color: rgba(255, 255, 255, 0.18);
+  box-shadow:
+    0 12px 34px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.10),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.04);
+}
+
+/* =====================================
+   Frosted glass dropdown menu panels
+   ===================================== */
+.glass-menu {
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.10) 0%,
+    rgba(255, 255, 255, 0.06) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-top-color: rgba(255, 255, 255, 0.24);
+  backdrop-filter: saturate(150%) blur(18px);
+  -webkit-backdrop-filter: saturate(150%) blur(18px);
+  box-shadow:
+    0 10px 28px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.06);
+}
+.dark .glass-menu, :root[data-theme="dark"] .glass-menu {
+  background: linear-gradient(
+    180deg,
+    rgba(20, 20, 22, 0.52) 0%,
+    rgba(20, 20, 22, 0.36) 100%
+  );
+  border-color: rgba(255, 255, 255, 0.10);
+  border-top-color: rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 10px 30px rgba(0, 0, 0, 0.44),
+    inset 0 1px 0 rgba(255, 255, 255, 0.10),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.04);
+}
+
+/* =====================================
+   Frosted glass chip (icon buttons)
+   ===================================== */
+.glass-chip {
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.10) 0%,
+    rgba(255, 255, 255, 0.06) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-top-color: rgba(255, 255, 255, 0.22);
+  backdrop-filter: saturate(150%) blur(14px);
+  -webkit-backdrop-filter: saturate(150%) blur(14px);
+  box-shadow:
+    0 6px 16px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.05);
+}
+.glass-chip:hover { filter: brightness(1.05); }
+.glass-chip:active { filter: brightness(0.98); }
+.dark .glass-chip, :root[data-theme="dark"] .glass-chip {
+  background: linear-gradient(
+    180deg,
+    rgba(20, 20, 22, 0.52) 0%,
+    rgba(20, 20, 22, 0.34) 100%
+  );
+  border-color: rgba(255, 255, 255, 0.10);
+  border-top-color: rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 8px 18px rgba(0, 0, 0, 0.42),
+    inset 0 1px 0 rgba(255, 255, 255, 0.10),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.04);
+}

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -17,7 +17,7 @@ export default function Hero() {
       .catch(() => setHeroStars(null));
   }, []);
   return (
-    <section className="relative overflow-hidden min-h-[calc(100vh-64px)] flex flex-col items-center justify-center bg-black text-white">
+  <section className="relative overflow-hidden min-h-screen flex flex-col items-center justify-center bg-black text-white">
       {/* Prism 背景：移动端与桌面端分别使用不同性能配置 */}
       {/* 移动端：低画质、DPR 上限 1.25、30 FPS、屏外暂停 */}
       <div className="block sm:hidden absolute inset-0 z-0">

--- a/src/components/home/Navbar.tsx
+++ b/src/components/home/Navbar.tsx
@@ -44,9 +44,10 @@ export default function Navbar() {
   const langLabel = locale === "en-US" ? "English" : locale === "ja-JP" ? "日本語" : "简体中文";
 
   return (
-    <nav ref={navRef} className="relative sticky top-0 z-50 backdrop-blur bg-background/80 border-b border-ui">
-      <div className="mx-auto max-w-6xl px-4 sm:px-6 h-16 flex items-center justify-between">
-        <div className="flex items-center gap-3">
+    <nav ref={navRef} className="fixed top-0 left-0 right-0 z-50">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 h-16 flex items-center">
+        <div className="glass-nav w-full h-12 rounded-2xl px-3 sm:px-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
           <Image src="/logo.webp" alt="AstrBot" width={32} height={32} />
           <span className="text-lg sm:text-xl font-semibold tracking-tight font-lexend">AstrBot</span>
           {releaseVersion && (
@@ -54,8 +55,8 @@ export default function Navbar() {
               {releaseVersion}
             </span>
           )}
-        </div>
-        <ul className="hidden md:flex items-center gap-3 text-sm">
+          </div>
+          <ul className="hidden md:flex items-center gap-3 text-sm">
           <li>
             <a href="https://docs.astrbot.app/what-is-astrbot.html" className="inline-flex items-center gap-2 h-9 px-3 rounded-full border border-ui opacity-80 hover:opacity-100 transition duration-200">
               <BookOpenIcon className="w-4 h-4" aria-hidden />
@@ -82,7 +83,7 @@ export default function Navbar() {
               <ChevronDownIcon aria-hidden className={`w-4 h-4 transition-transform duration-200 ${openLang ? 'rotate-180' : ''}`} />
             </button>
             {openLang && (
-              <ul className="absolute right-0 mt-5 w-28 rounded-lg border border-ui bg-background shadow-lg origin-top-right animate-dropdown">
+              <ul className="glass-menu absolute right-0 mt-5 w-28 rounded-xl origin-top-right animate-dropdown">
                 <li className="px-3 py-2 hover:bg-black/[.04] dark:hover:bg-white/[.06]">
                   <button onClick={() => { setLocale("zh-CN"); setOpenLang(false); }} className="flex items-center gap-2 w-full text-left">
                     <GlobeAsiaAustraliaIcon className="w-4 h-4 opacity-80" aria-hidden />
@@ -114,7 +115,7 @@ export default function Navbar() {
               <ChevronDownIcon aria-hidden className={`w-4 h-4 transition-transform duration-200 ${openMore ? 'rotate-180' : ''}`} />
             </button>
             {openMore && (
-              <ul className="absolute right-0 mt-5 w-auto rounded-lg border border-ui bg-background shadow-lg origin-top-right animate-dropdown whitespace-nowrap">
+              <ul className="glass-menu absolute right-0 mt-5 w-auto rounded-xl origin-top-right animate-dropdown whitespace-nowrap">
                 <li>
                   <a href="https://plugins.astrbot.app/" className="flex items-center gap-2 px-3 py-2 hover:bg-black/[.04] dark:hover:bg-white/[.06]">
                     <PuzzlePieceIcon className="w-4 h-4 opacity-80" aria-hidden />
@@ -138,21 +139,22 @@ export default function Navbar() {
           </li>
         </ul>
         <button
-          className="md:hidden inline-flex items-center justify-center h-9 w-9 rounded-lg border border-ui bg-background/80 backdrop-blur transition active:scale-[0.98]"
+          className="md:hidden inline-flex items-center justify-center h-9 w-9 rounded-xl glass-chip transition active:scale-[0.98]"
           onClick={() => setOpenMenu((v) => !v)}
           aria-label="menu"
           aria-expanded={openMenu}
         >
           <div className="relative w-4 h-4">
-            <span className={`absolute left-1/2 top-1/2 h-0.5 w-4 -translate-x-1/2 -translate-y-1/2 bg-foreground transition-transform duration-300 ${openMenu ? 'rotate-45' : '-translate-y-[4px]'}`} />
-            <span className={`absolute left-1/2 top-1/2 h-0.5 w-4 -translate-x-1/2 -translate-y-1/2 bg-foreground transition-transform duration-300 ${openMenu ? '-rotate-45' : 'translate-y-[4px]'}`} />
+            <span className={`absolute left-1/2 top-1/2 h-0.5 w-4 -translate-x-1/2 -translate-y-1/2 bg-foreground/90 rounded transition-transform duration-300 ${openMenu ? 'rotate-45' : '-translate-y-[4px]'}`} />
+            <span className={`absolute left-1/2 top-1/2 h-0.5 w-4 -translate-x-1/2 -translate-y-1/2 bg-foreground/90 rounded transition-transform duration-300 ${openMenu ? '-rotate-45' : 'translate-y-[4px]'}`} />
           </div>
         </button>
+        </div>
       </div>
       {openMenu && (
         <div className="md:hidden absolute left-0 right-0 top-16 z-40">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 pb-4 mt-2">
-            <div className="rounded-2xl border border-ui bg-background/90 backdrop-blur shadow-lg p-4 animate-dropdown origin-top">
+            <div className="glass-menu rounded-2xl p-4 animate-dropdown origin-top">
               <ul className="flex flex-col gap-2 text-sm">
                 <li>
                   <a href="https://docs.astrbot.app/what-is-astrbot.html" className="inline-flex items-center gap-2 h-10 px-3 rounded-full border border-ui opacity-80 hover:opacity-100 transition">


### PR DESCRIPTION
## Sourcery 摘要

为导航、下拉菜单和按钮添加磨砂玻璃样式，并在导航栏和移动菜单中应用这些样式；同时调整 Hero 组件以占据整个视口高度

新功能：
- 添加 `.glass-nav`、`.glass-menu` 和 `.glass-chip` CSS 类，以实现磨砂玻璃效果并支持浅色/深色主题

改进：
- 将 `glass-nav` 应用于主导航栏容器，并将徽标/菜单元素包裹在磨砂玻璃样式中
- 将 `glass-menu` 用于下拉面板和移动菜单容器，取代了之前的边框/UI 背景
- 更新移动菜单切换按钮以使用 `glass-chip` 样式，具有圆角 span 和一致的悬停/激活状态
- 更改 Hero 部分以使用全视口高度 (`min-h-screen`)，以实现一致的布局

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add frosted glass styling to navigation, dropdowns, and buttons, and apply those styles in the Navbar and mobile menu; also adjust the Hero component to occupy the full viewport height

New Features:
- Add `.glass-nav`, `.glass-menu`, and `.glass-chip` CSS classes for frosted glass effects with light/dark theme support

Enhancements:
- Apply `glass-nav` to the main Navbar container and wrap logo/menu elements in the frosted glass style
- Use `glass-menu` for dropdown panels and mobile menu container, replacing the previous border/UI backgrounds
- Update the mobile menu toggle to use `glass-chip` styling with rounded spans and consistent hover/active states
- Change Hero section to use full viewport height (`min-h-screen`) for consistent layout

</details>