### PR TITLE
feat: 添加 MagnetLines 和背景

### DIFF
--- a/src/assets/globals.css
+++ b/src/assets/globals.css
@@ -142,6 +142,13 @@ html.snap-temp-disable {
 /* Unified UI border utility */
 .border-ui { border-color: var(--border-ui) !important; }
 
+.card-surface {
+  background-color: #f3f4f6; 
+}
+html.dark .card-surface, :root[data-theme="dark"] .card-surface {
+  background-color: #121316; 
+}
+
 /* Unify theme transition timing across interactive elements */
 a, button, .btn-brand, .btn-outline-brand, .tag-brand, .border-ui {
   transition: color .2s ease, background-color .2s ease, border-color .2s ease, opacity .2s ease;

--- a/src/components/home/Plugins.tsx
+++ b/src/components/home/Plugins.tsx
@@ -5,6 +5,7 @@ import Reveal from "../ui/Reveal";
 import { useI18n } from "../i18n/I18nProvider";
 import { PuzzlePieceIcon, ArrowRightIcon, EllipsisHorizontalIcon } from "@heroicons/react/24/solid";
 import CardSwap, { Card } from "../ui/CardSwap";
+import MagnetLines from "../ui/MagnetLines";
 
 export default function Plugins() {
   const { t } = useI18n();
@@ -60,8 +61,33 @@ export default function Plugins() {
     return () => io.disconnect();
   }, [hasFetched]);
   return (
-    <section ref={sectionRef} id="plugins" className="min-h-[calc(100vh-64px)] flex items-center py-12 sm:py-16 overflow-hidden">
-      <div className="mx-auto max-w-6xl px-4 sm:px-6 w-full relative -translate-y-2 sm:-translate-y-3 lg:-translate-y-12">
+    <section ref={sectionRef} id="plugins" className="relative min-h-[calc(100vh-64px)] flex items-center py-12 sm:py-16 overflow-hidden">
+      {/** 平板（md）使用更大间距；桌面（lg+）使用原密度；移动端隐藏 **/}
+      <div className="absolute inset-0 z-0 pointer-events-none select-none hidden md:block lg:hidden" aria-hidden="true">
+        <MagnetLines
+          rows={8}
+          columns={14}
+          containerSize="100%"
+          lineColor="var(--border-ui)"
+          lineWidth="2px"
+          lineHeight="32px"
+          baseAngle={SKEW}
+          className="opacity-45"
+        />
+      </div>
+      <div className="absolute inset-0 z-0 pointer-events-none select-none hidden lg:block" aria-hidden="true">
+        <MagnetLines
+          rows={10}
+          columns={24}
+          containerSize="100%"
+          lineColor="var(--border-ui)"
+          lineWidth="2px"
+          lineHeight="28px"
+          baseAngle={SKEW}
+          className="opacity-45"
+        />
+      </div>
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 w-full relative z-10 -translate-y-2 sm:-translate-y-3 lg:-translate-y-12">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
           <div className="lg:pr-6">
             <Reveal as="h2" className="text-left text-3xl sm:text-4xl font-semibold tracking-tight mb-4 gradient-title" delay={0}>
@@ -92,7 +118,7 @@ export default function Plugins() {
                   <Card
                     key={`skeleton-${i}`}
                     style={{ width: CARD_WIDTH, height: CARD_HEIGHT, transform, zIndex: zIndex as unknown as number }}
-                    className="p-5 sm:p-6 select-none pointer-events-none"
+                    className="p-5 sm:p-6 select-none pointer-events-none card-surface"
                     aria-hidden="true"
                   >
                     <div className="h-full w-full">
@@ -134,7 +160,7 @@ export default function Plugins() {
                 }}
               >
                 {plugins.slice(0, Math.min(8, plugins.length)).map((p) => (
-                  <Card key={p.key} className="group p-5 sm:p-6 cursor-pointer">
+                  <Card key={p.key} className="group p-5 sm:p-6 cursor-pointer card-surface">
                     <div className="relative z-10">
                       <div className="flex items-start justify-between gap-3">
                         <h4 className="text-base font-semibold leading-snug line-clamp-1">{p.name}</h4>
@@ -166,7 +192,7 @@ export default function Plugins() {
                   </Card>
                 ))}
                 {/** 更多插件卡片 */}
-                <Card key="more-card" className="group p-5 sm:p-6 cursor-pointer" onClick={() => window.open('https://plugins.astrbot.app', '_blank', 'noopener,noreferrer')}>
+                <Card key="more-card" className="group p-5 sm:p-6 cursor-pointer card-surface" onClick={() => window.open('https://plugins.astrbot.app', '_blank', 'noopener,noreferrer')}>
                   <div className="relative z-10">
                     <h4 className="text-base font-semibold leading-snug line-clamp-1">{t('plugins.more')}</h4>
                     <p className="mt-3 text-sm opacity-80 line-clamp-3 min-h-[3.4rem]">{t('plugins.subtitle')}</p>

--- a/src/components/ui/MagnetLines.tsx
+++ b/src/components/ui/MagnetLines.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import React, { useRef, useEffect, CSSProperties } from 'react';
+
+// Allow CSS custom properties like --rotate in inline style objects
+type CSSVars = { [key: `--${string}`]: string | number };
+
+interface MagnetLinesProps {
+  rows?: number;
+  columns?: number;
+  containerSize?: string;
+  lineColor?: string;
+  lineWidth?: string;
+  lineHeight?: string;
+  baseAngle?: number;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const MagnetLines: React.FC<MagnetLinesProps> = ({
+  rows = 9,
+  columns = 9,
+  containerSize = '80vmin',
+  lineColor = '#efefef',
+  lineWidth = '1vmin',
+  lineHeight = '6vmin',
+  baseAngle = -10,
+  className = '',
+  style = {}
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const items = container.querySelectorAll<HTMLSpanElement>('span');
+
+    const onPointerMove = (pointer: { x: number; y: number }) => {
+      items.forEach(item => {
+        const rect = item.getBoundingClientRect();
+        const centerX = rect.x + rect.width / 2;
+        const centerY = rect.y + rect.height / 2;
+
+        const b = pointer.x - centerX;
+        const a = pointer.y - centerY;
+        const c = Math.sqrt(a * a + b * b) || 1;
+        const r = ((Math.acos(b / c) * 180) / Math.PI) * (pointer.y > centerY ? 1 : -1);
+
+        item.style.setProperty('--rotate', `${r}deg`);
+      });
+    };
+
+    const handlePointerMove = (e: PointerEvent) => {
+      onPointerMove({ x: e.x, y: e.y });
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+
+    if (items.length) {
+      const middleIndex = Math.floor(items.length / 2);
+      const rect = items[middleIndex].getBoundingClientRect();
+      onPointerMove({ x: rect.x, y: rect.y });
+    }
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+    };
+  }, []);
+
+  const total = rows * columns;
+  const spans = Array.from({ length: total }, (_, i) => (
+    <span
+      key={i}
+      className="block origin-center"
+      style={{
+        backgroundColor: lineColor,
+        width: lineWidth,
+        height: lineHeight,
+        ['--rotate']: `${baseAngle}deg`,
+        transform: 'rotate(var(--rotate))',
+        willChange: 'transform'
+      } as CSSProperties & CSSVars}
+    />
+  ));
+
+  return (
+    <div
+      ref={containerRef}
+      className={`grid place-items-center ${className}`}
+      style={{
+        gridTemplateColumns: `repeat(${columns}, 1fr)`,
+        gridTemplateRows: `repeat(${rows}, 1fr)`,
+        width: containerSize,
+        height: containerSize,
+        ...style
+      }}
+    >
+      {spans}
+    </div>
+  );
+};
+
+export default MagnetLines;


### PR DESCRIPTION
## Sourcery 总结

引入一个新的 MagnetLines 组件，用于在 Plugins 部分渲染动态背景线条网格，并通过一个新的 `card-surface` 工具统一卡片样式，同时调整布局以实现正确的背景分层。

新功能：
- 添加 MagnetLines 组件，用于渲染交互式旋转线条网格
- 在 Plugins 部分的中等和大型断点处嵌入 MagnetLines 背景层

改进：
- 引入 `card-surface` CSS 工具类，并将其应用于所有插件卡片，以实现主题的一致性
- 重构 Plugins 部分的标记，通过 z-index 和定位调整将背景图形分层到内容后面

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new MagnetLines component to render dynamic background line grids in the Plugins section, and unify card styling via a new card-surface utility while adjusting layout for proper background layering.

New Features:
- Add MagnetLines component for rendering interactive rotating line grids
- Embed MagnetLines background layers in the Plugins section at medium and large breakpoints

Enhancements:
- Introduce card-surface CSS utility and apply it to all plugin cards for consistent theming
- Refactor Plugins section markup to layer background graphics behind content with z-index and positioning adjustments

</details>